### PR TITLE
April 2025 Fork Sync

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -48,7 +48,7 @@ module "api" {
     DJANGO_DANDI_API_URL                           = "https://api-dandi.emberarchive.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub-dandi.emberarchive.org/"
     DJANGO_DANDI_DEV_EMAIL                         = var.dev_email
-    DJANGO_DANDI_ADMIN_EMAIL                       = "info@dandiarchive.org"
+    DJANGO_DANDI_ADMIN_EMAIL                       = "info@emberarchive.org"
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.doi_api_password

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -78,7 +78,7 @@ resource "aws_route53_record" "email-spf" {
   ttl     = "300"
   records = [
     "v=spf1 include:spf.improvmx.com ~all",
-    "google-site-verification=PRleUQ6hPcZFE9qVEQ0koOrCWMNwnMHz7QXWV5UDpFU",
+    # "google-site-verification=PRleUQ6hPcZFE9qVEQ0koOrCWMNwnMHz7QXWV5UDpFU",
   ]
 }
 

--- a/terraform/staging_pipeline.tf
+++ b/terraform/staging_pipeline.tf
@@ -48,7 +48,7 @@ module "api_staging" {
     DJANGO_DANDI_API_URL                           = "https://api-dandi-sandbox.emberarchive.org"
     DJANGO_DANDI_JUPYTERHUB_URL                    = "https://hub-dandi.emberarchive.org/"
     DJANGO_DANDI_DEV_EMAIL                         = var.dev_email
-    DJANGO_DANDI_ADMIN_EMAIL                       = "info@dandiarchive.org"
+    DJANGO_DANDI_ADMIN_EMAIL                       = "info@emberarchive.org"
   }
   additional_sensitive_django_vars = {
     DJANGO_DANDI_DOI_API_PASSWORD = var.test_doi_api_password


### PR DESCRIPTION
closes #9

Sync `apl-setup` with latest from `dandi/dandi-infrastructure:master`

Summary of Changes:
- Adds a variable for DJANGO_DANDI_ADMIN_EMAIL which I've updated to be "EMBER-ified"
- (Commented out) Adds a "google site verification" record. I've commented this out for now since we don't currently have a google verification code (at least to my knowledge - I'm not 100% what that even entials)
    - I've added a ticket (https://github.com/aplbrain/dandi-infrastructure/issues/12) to track this as a future TODO for us


Steps Taken:
- [X] New [issue](https://github.com/aplbrain/dandi-infrastructure/issues/9) to track sync
- [X] New branch from issue `9-sync-fork-april-2025`
  - Note that this branch is created off of our default branch, `apl-setup`, so it has all of our latest changes 
- [X] Sync'ed our `master1 with `dandi/dandi-infrastruture:master`
  - Using GitHub buttton on this repository’s home page
- [X] Open PR to merge `master` into `9-sync-fork-april-2025`
  - (source) `master` contains the latest from `dandi/dandi-infrastruture:master`
  - (target) `9-sync-fork-april-2025` contains the latest of our EMBER updates
- [X] Resolve merge conflicts 
  - not needed in this case
- [x] Merge first PR (https://github.com/aplbrain/dandi-infrastructure/pull/10)
- [x] Open a second PR to merge  `9-sync-fork-april-2025` into `apl-setup`
- [x] Resolve merge conflicts
- [x] EMBER-ify if needed
- [ ] Merge second PR (https://github.com/aplbrain/dandi-infrastructure/pull/11)
