### PR TITLE
Update bucket policy to reflect itsd policies

### DIFF
--- a/terraform/modules/dandiset_bucket/log_bucket.tf
+++ b/terraform/modules/dandiset_bucket/log_bucket.tf
@@ -61,9 +61,9 @@ data "aws_iam_policy_document" "dandiset_log_bucket_policy" {
     }
   }
 
-  # APL policy
+  # APL ITSD Managed policy
   statement {
-    # sid = "AllowSSLRequestsOnly"
+    sid = "AllowSSLRequestsOnly"
 
     resources = [
       "${aws_s3_bucket.log_bucket.arn}",

--- a/terraform/modules/dandiset_bucket/log_bucket.tf
+++ b/terraform/modules/dandiset_bucket/log_bucket.tf
@@ -60,6 +60,33 @@ data "aws_iam_policy_document" "dandiset_log_bucket_policy" {
       identifiers = ["logging.s3.amazonaws.com"]
     }
   }
+
+  # APL policy
+  statement {
+    # sid = "AllowSSLRequestsOnly"
+
+    resources = [
+      "${aws_s3_bucket.log_bucket.arn}",
+      "${aws_s3_bucket.log_bucket.arn}/*",
+    ]
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "dandiset_log_bucket_policy" {

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -306,6 +306,35 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
       }
     }
   }
+
+  # APL policy
+  dynamic "statement" {
+    content {
+      sid = "AllowSSLRequestsOnly"
+
+      resources = [
+        "${aws_s3_bucket.dandiset_bucket.arn}",
+        "${aws_s3_bucket.dandiset_bucket.arn}/*",
+      ]
+
+      actions = [
+        "s3:*",
+      ]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SecureTransport"
+        values   = ["false"]
+      }
+
+      effect = "Deny"
+
+      principals {
+        identifiers = ["*"]
+        type        = "*"
+      }
+    }
+  }
 }
 
 

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -309,7 +309,7 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
 
   # APL policy
   statement {
-    sid = "AllowSSLRequestsOnly"
+    # sid = "AllowSSLRequestsOnly"
 
     resources = [
       "${aws_s3_bucket.dandiset_bucket.arn}",

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -307,9 +307,9 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
     }
   }
 
-  # APL policy
+  # APL ITSD Managed policy
   statement {
-    # sid = "AllowSSLRequestsOnly"
+    sid = "AllowSSLRequestsOnly"
 
     resources = [
       "${aws_s3_bucket.dandiset_bucket.arn}",

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -309,30 +309,28 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
 
   # APL policy
   statement {
-    content {
-      sid = "AllowSSLRequestsOnly"
+    sid = "AllowSSLRequestsOnly"
 
-      resources = [
-        "${aws_s3_bucket.dandiset_bucket.arn}",
-        "${aws_s3_bucket.dandiset_bucket.arn}/*",
-      ]
+    resources = [
+      "${aws_s3_bucket.dandiset_bucket.arn}",
+      "${aws_s3_bucket.dandiset_bucket.arn}/*",
+    ]
 
-      actions = [
-        "s3:*",
-      ]
+    actions = [
+      "s3:*",
+    ]
 
-      condition {
-        test     = "StringEquals"
-        variable = "aws:SecureTransport"
-        values   = ["false"]
-      }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
 
-      effect = "Deny"
+    effect = "Deny"
 
-      principals {
-        identifiers = ["*"]
-        type        = "*"
-      }
+    principals {
+      identifiers = ["*"]
+      type        = "*"
     }
   }
 }

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -321,7 +321,7 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
     ]
 
     condition {
-      test     = "StringEquals"
+      test     = "Bool"
       variable = "aws:SecureTransport"
       values   = ["false"]
     }

--- a/terraform/modules/dandiset_bucket/main.tf
+++ b/terraform/modules/dandiset_bucket/main.tf
@@ -308,7 +308,7 @@ data "aws_iam_policy_document" "dandiset_bucket_policy" {
   }
 
   # APL policy
-  dynamic "statement" {
+  statement {
     content {
       sid = "AllowSSLRequestsOnly"
 


### PR DESCRIPTION
Closes #14 


Adds "AllowSSLRequestsOnly" policy to dandiset and log buckets. This policy is auto-added to all buckets in our AWS accounts due to ITSD's setup. Adding this policy through should "sync" the terraform state with the actual AWS S3 bucket such that we won't see so many changes on each Terraform Plan/Apply.

Caveat: I wasn't able to do add this policy to the "x-storage" buckets, because those buckets and their policies are defined in the [terraform-heroku-resonant](https://github.com/kitware-resonant/terraform-heroku-resonant/blob/a395e3ca1c269b6a363e8dbf4a1ca503ed66d8b3/modules/storage/main.tf) repository
