### PR TITLE
Switch to Open Data bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,12 +22,12 @@ provider "aws" {
 provider "aws" {
   alias               = "sponsored"
   region              = "us-east-1"
-  allowed_account_ids = ["886436969878"]
+  allowed_account_ids = ["886436969878"] // TODO
 
   // This will authenticate using credentials from the project account, then assume the
   // "dandi-infrastructure" role from the sponsored account to manage resources there
   assume_role {
-    role_arn = "arn:aws:iam::886436969878:role/dandi-infrastructure"  
+    role_arn = "arn:aws:iam::886436969878:role/dandi-infrastructure"   // TODO
   }
 
   # Must set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY envvars for project account in Terraform

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,12 +22,12 @@ provider "aws" {
 provider "aws" {
   alias               = "sponsored"
   region              = "us-east-1"
-  allowed_account_ids = ["886436969878"] // TODO
+  allowed_account_ids = ["650477180493"]
 
   // This will authenticate using credentials from the project account, then assume the
   // "dandi-infrastructure" role from the sponsored account to manage resources there
   assume_role {
-    role_arn = "arn:aws:iam::886436969878:role/dandi-infrastructure"   // TODO
+    role_arn = "arn:aws:iam::650477180493:role/dandi-infrastructure"
   }
 
   # Must set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY envvars for project account in Terraform

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -1,11 +1,12 @@
 module "sponsored_dandiset_bucket" {
   source                                = "./modules/dandiset_bucket"
-  bucket_name                           = "ember-dandi-archive"
+  bucket_name                           = "ember-open-data"
   public                                = true
   versioning                            = true
+  aws_open_data                         = true
   allow_cross_account_heroku_put_object = true
   heroku_user                           = data.aws_iam_user.api
-  log_bucket_name                       = "ember-dandi-archive-logs"
+  log_bucket_name                       = "ember-open-data-logs"
   providers = {
     aws         = aws.sponsored
     aws.project = aws

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -33,7 +33,7 @@ module "sponsored_embargo_bucket" {
   heroku_user     = data.aws_iam_user.api
   log_bucket_name = "ember-dandi-archive-embargo-logs"
   providers = {
-    aws         = aws.sponsored
+    aws         = aws
     aws.project = aws
   }
 }

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -13,6 +13,17 @@ module "sponsored_dandiset_bucket" {
   }
 }
 
+import {
+  
+  to = module.sponsored_dandiset_bucket.aws_s3_bucket.dandiset_bucket
+  id = "ember-open-data"
+}
+
+import {
+  to = module.sponsored_dandiset_bucket.aws_s3_bucket.log_bucket
+  id = "ember-open-data-logs"
+}
+
 // Note: While the embargo bucket is created in AWS, it is NOT actually used.
 // Embargoed data is stored in the public bucket defined above
 module "sponsored_embargo_bucket" {

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -13,6 +13,8 @@ module "sponsored_dandiset_bucket" {
   }
 }
 
+// Note: While the embargo bucket is created in AWS, it is NOT actually used.
+// Embargoed data is stored in the public bucket defined above
 module "sponsored_embargo_bucket" {
   source          = "./modules/dandiset_bucket"
   bucket_name     = "ember-dandi-archive-private"

--- a/terraform/sponsored_bucket.tf
+++ b/terraform/sponsored_bucket.tf
@@ -20,7 +20,7 @@ module "sponsored_embargo_bucket" {
   heroku_user     = data.aws_iam_user.api
   log_bucket_name = "ember-dandi-archive-private-logs"
   providers = {
-    aws         = aws
+    aws         = aws.sponsored
     aws.project = aws
   }
 }

--- a/terraform/staging_bucket.tf
+++ b/terraform/staging_bucket.tf
@@ -23,7 +23,8 @@ import {
   id = "ember-open-data-sandbox-logs"
 }
 
-
+// Note: While the embargo bucket is created in AWS, it is NOT actually used.
+// Embargoed data is stored in the public bucket defined above
 module "staging_embargo_bucket" {
   source          = "./modules/dandiset_bucket"
   bucket_name     = "ember-dandi-api-sandbox-private-dandisets"


### PR DESCRIPTION
**to-do before merge**
- [x] ~edit MR to include moving embargo bucket~ done. but doesn't really matter since the embargo bucket is not actuall used (all data is stored in the public bucket)
- [x] Setup `dandi-infrastructure` IAM role according to instructions in boostrap.md in the Open Data account
- [x] Terraform state remove current bucket
   - we did this with the sandbox so that we didn't have to delete the old bucket (yet) but could still make terraform "forget" about it  
- [x] Switch to open data account id
- [x] Set `aws_open_data           = true` in sponsored_bucket.tf for open data bucket

Closes #16