### PR TITLE
add import statements since buckets already exist

### DIFF
--- a/terraform/staging_bucket.tf
+++ b/terraform/staging_bucket.tf
@@ -13,15 +13,15 @@ module "staging_dandiset_bucket" {
   }
 }
 
-# import {
-#   to = module.staging_dandiset_bucket.aws_s3_bucket.dandiset_bucket
-#   id = "ember-public-data-sandbox"
-# }
-# 
-# import {
-#   to = module.staging_dandiset_bucket.aws_s3_bucket.log_bucket
-#   id = "ember-public-data-sandbox-logs"
-# }
+import {
+  to = module.staging_dandiset_bucket.aws_s3_bucket.dandiset_bucket
+  id = "ember-public-data-sandbox"
+}
+
+import {
+  to = module.staging_dandiset_bucket.aws_s3_bucket.log_bucket
+  id = "ember-public-data-sandbox-logs"
+}
 
 # Note: this bucket is no longer being used
 module "staging_embargo_bucket" {


### PR DESCRIPTION
Add import statemetnts back in (with the new bucket names) since the buckets already exist. The import statements allow terraform to "find" the existing buckets vs. trying to create them